### PR TITLE
Is revert error

### DIFF
--- a/packages/ethers-ccip-read-provider/src/index.ts
+++ b/packages/ethers-ccip-read-provider/src/index.ts
@@ -41,6 +41,7 @@ interface RevertError {
         data: string;
       };
     };
+    message: string;
   };
 }
 
@@ -55,13 +56,15 @@ async function handleCall(
 ): Promise<{ transaction: TransactionRequest; result: BytesLike }> {
   for (let i = 0; i < maxCalls; i++) {
     let result;
-    let bytes: any;
+    let bytes: Uint8Array;
     try {
       result = await provider.parent.perform('call', params);
       bytes = arrayify(result);
     } catch (e) {
       if (isRevertError(e)) {
         bytes = arrayify(e.error.data.originalError.data);
+      }else{
+        return logger.throwError('The error message does not contain originalError', Logger.errors.UNKNOWN_ERROR)
       }
     }
     if (bytes.length % 32 !== 4 || hexlify(bytes.slice(0, 4)) !== CCIP_READ_INTERFACE.getSighash('OffchainLookup')) {

--- a/packages/ethers-ccip-read-provider/src/index.ts
+++ b/packages/ethers-ccip-read-provider/src/index.ts
@@ -63,8 +63,8 @@ async function handleCall(
     } catch (e) {
       if (isRevertError(e)) {
         bytes = arrayify(e.error.data.originalError.data);
-      }else{
-        return logger.throwError('The error message does not contain originalError', Logger.errors.UNKNOWN_ERROR)
+      } else {
+        return logger.throwError('The error message does not contain originalError', Logger.errors.UNKNOWN_ERROR);
       }
     }
     if (bytes.length % 32 !== 4 || hexlify(bytes.slice(0, 4)) !== CCIP_READ_INTERFACE.getSighash('OffchainLookup')) {

--- a/packages/ethers-ccip-read-provider/src/index.ts
+++ b/packages/ethers-ccip-read-provider/src/index.ts
@@ -34,18 +34,18 @@ function hasSigner(obj: any): obj is HasSigner {
   return (obj as unknown as HasSigner).getSigner !== undefined;
 }
 
-interface RevertError{
+interface RevertError {
   error: {
     data: {
       originalError: {
         data: string;
-      }
-    }
-  }
+      };
+    };
+  };
 }
 
-function isRevertError(e: any): e is RevertError{
-  return typeof e?.error?.data?.originalError?.data  === 'string';
+function isRevertError(e: any): e is RevertError {
+  return typeof e?.error?.data?.originalError?.data === 'string';
 }
 
 async function handleCall(
@@ -54,13 +54,13 @@ async function handleCall(
   maxCalls = 4
 ): Promise<{ transaction: TransactionRequest; result: BytesLike }> {
   for (let i = 0; i < maxCalls; i++) {
-    let result
-    let bytes:any
-    try{
+    let result;
+    let bytes: any;
+    try {
       result = await provider.parent.perform('call', params);
       bytes = arrayify(result);
-    }catch(e){
-      if(isRevertError(e)){
+    } catch (e) {
+      if (isRevertError(e)) {
         bytes = arrayify(e.error.data.originalError.data);
       }
     }


### PR DESCRIPTION
When I was testing against ropsten, the call was throwing an error and the original error was within `e.error.data.originalError.data`