### PR TITLE
Replace @chainlink's CCIPReadProvider with ethers.js

### DIFF
--- a/packages/examples/trusted-gateway-token/client/package.json
+++ b/packages/examples/trusted-gateway-token/client/package.json
@@ -50,10 +50,9 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@chainlink/ethers-ccip-read-provider": "0.2.2",
     "@types/node-fetch": "^2.5.12",
     "dotenv": "^10.0.0",
-    "ethers": "^5.4.4",
+    "ethers": "^5.6.9",
     "jayson": "^3.6.4",
     "node-fetch": "^2.6.1"
   }

--- a/packages/examples/trusted-gateway-token/client/src/index.ts
+++ b/packages/examples/trusted-gateway-token/client/src/index.ts
@@ -1,5 +1,6 @@
+import { providers, Transaction } from 'ethers';
+
 const ethers = require('ethers');
-const ccipread = require('@chainlink/ethers-ccip-read-provider');
 const fs = require('fs');
 
 require('dotenv').config({ path: '../.env' });
@@ -14,9 +15,23 @@ const abi = JSON.parse(
 const RECIPIENT = '0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199';
 const { TOKEN_ADDRESS, PROVIDER_URL, SENDER_ACCOUNT_INDEX } = process.env;
 
-const provider = new ccipread.CCIPReadProvider(
-  new ethers.providers.JsonRpcProvider(PROVIDER_URL)
-);
+class MyCustomProvider extends providers.JsonRpcProvider {
+  async ccipReadFetch(
+    tx: Transaction,
+    calldata: string,
+    urls: Array<string>
+  ): Promise<null | string> {
+    urls = urls.filter((u: any) => isSafeUrl(u));
+    return super.ccipReadFetch(tx, calldata, urls);
+  }
+}
+
+function isSafeUrl(url: string): boolean {
+  console.log(`Allowing ${url}`);
+  return true;
+}
+
+const provider = new MyCustomProvider(PROVIDER_URL);
 const signer = provider.getSigner(parseInt(SENDER_ACCOUNT_INDEX as string));
 const erc20 = new ethers.Contract(TOKEN_ADDRESS, abi, signer);
 
@@ -24,16 +39,30 @@ async function main() {
   const amount = 1;
   const sender = await signer.getAddress();
 
-  console.log(`SENDER ${sender} balance ${await erc20.balanceOf(sender)}`);
+  console.log(`CCIP enabled: ${!provider.disableCcipRead}`);
+
   console.log(
-    `RECIPIENT ${RECIPIENT} balance ${await erc20.balanceOf(RECIPIENT)}`
+    `SENDER ${sender} balance ${await erc20.balanceOf(sender, {
+      ccipReadEnabled: true,
+    })}`
+  );
+  console.log(
+    `RECIPIENT ${RECIPIENT} balance ${await erc20.balanceOf(RECIPIENT, {
+      ccipReadEnabled: true,
+    })}`
   );
   console.log(`TRANSFER ${amount} from ${sender} to ${RECIPIENT}`);
   const tx = await erc20.transfer(RECIPIENT, amount);
   await tx.wait();
-  console.log(`SENDER ${sender} balance ${await erc20.balanceOf(sender)}`);
   console.log(
-    `RECIPIENT ${RECIPIENT} balance ${await erc20.balanceOf(RECIPIENT)}`
+    `SENDER ${sender} balance ${await erc20.balanceOf(sender, {
+      ccipReadEnabled: true,
+    })}`
+  );
+  console.log(
+    `RECIPIENT ${RECIPIENT} balance ${await erc20.balanceOf(RECIPIENT, {
+      ccipReadEnabled: true,
+    })}`
   );
 }
 

--- a/packages/examples/trusted-gateway-token/contracts/package.json
+++ b/packages/examples/trusted-gateway-token/contracts/package.json
@@ -18,7 +18,7 @@
     "chai": "^4.2.0",
     "dotenv": "^10.0.0",
     "ethereum-waffle": "^3.0.0",
-    "ethers": "^5.0.0",
+    "ethers": "^5.6.9",
     "hardhat": "^2.7.1"
   },
   "dependencies": {

--- a/packages/examples/trusted-gateway-token/server/package.json
+++ b/packages/examples/trusted-gateway-token/server/package.json
@@ -64,9 +64,9 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@chainlink/ccip-read-server": "0.2.1",
+    "@chainlink/ccip-read-server": "^0.2.1",
     "dotenv": "^10.0.0",
-    "ethers": "^5.4.4",
+    "ethers": "^5.6.9",
     "ts-node": "^10.2.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     },
     "dependencies": {
         "cors": "^2.8.5",
-        "ethers": "^5.3.1",
+        "ethers": "^5.6.9",
         "express": "^4.17.1"
     }
 }


### PR DESCRIPTION
- Bumped ethers js package versions to latest.
- Dropped @chainlink/ethers-ccip-read-provider in favor of newest ethers' js implementation.