### PR TITLE
Add multicall() Support

### DIFF
--- a/packages/server/tests/ccipRead.test.ts
+++ b/packages/server/tests/ccipRead.test.ts
@@ -1,15 +1,14 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { ethers } from 'ethers';
 import supertest from 'supertest';
 import { Server } from '../src/index';
+import { FunctionFragment, Interface, Result, defaultAbiCoder } from 'ethers/lib/utils';
 
 chai.use(chaiAsPromised);
-
 const TEST_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 async function doCall(server: Server, abi: string[], to: string, funcname: string, args: any[]) {
-  const iface = new ethers.utils.Interface(abi);
+  const iface = new Interface(abi);
   const handler = server.handlers[iface.getSighash(funcname)];
   if (!handler) {
     throw Error('Unknown handler');
@@ -92,7 +91,7 @@ describe('CCIP-Read', () => {
         },
       ]);
       const app = server.makeApp('/rpc/');
-      const iface = new ethers.utils.Interface(abi);
+      const iface = new Interface(abi);
       const calldata = iface.encodeFunctionData('getSignedBalance', [TEST_ADDRESS]);
       await supertest(app)
         .get(`/rpc/${TEST_ADDRESS}/${calldata}.json`)
@@ -117,7 +116,7 @@ describe('CCIP-Read', () => {
         },
       ]);
       const app = server.makeApp('/rpc/');
-      const iface = new ethers.utils.Interface(abi);
+      const iface = new Interface(abi);
       const calldata = iface.encodeFunctionData('getSignedBalance', [TEST_ADDRESS]);
       await supertest(app)
         .post('/rpc/')
@@ -140,7 +139,7 @@ describe('CCIP-Read', () => {
     it('returns a 404 for undefined functions', async () => {
       const server = new Server();
       const app = server.makeApp('/rpc/');
-      const iface = new ethers.utils.Interface(abi);
+      const iface = new Interface(abi);
       const calldata = iface.encodeFunctionData('getSignedBalance', [TEST_ADDRESS]);
       await supertest(app)
         .get(`/rpc/${TEST_ADDRESS}/${calldata}.json`)
@@ -166,66 +165,95 @@ describe('CCIP-Read', () => {
     });
   });
 
-  describe('multicall tests', () => {
-    const multicall_iface = new ethers.utils.Interface([
-      'function multicall(bytes[] calldata data) external returns (bytes[] memory results)'
-    ]);
-    const multicall_frag = multicall_iface.getFunction('multicall');
-    const test_iface = new ethers.utils.Interface([
-      'function aaa(uint256 x) external returns (uint256)',
-      'function bbb(string y, uint256 z) external returns (uint256, string)',
-    ]);
-    it('answers multiple requests', async () => {
-      const server = new Server();
-      server.add(test_iface, [
-        {
-          type: 'aaa',
-          func([x]) { return [x.toNumber() + 1]; }
-        },
-        {
-          type: 'bbb',
-          func([y, z]) { return [z.toNumber() + 1, y.toUpperCase()]; }
-        },
+  describe('multicall() tests', () => {
+    
+    type Ok = (args: any[], res: Result) => void;
+    type Err = (args: any[], data: string) => void;
+    class Impl {
+      iface: Interface;
+      frag: FunctionFragment;
+      f: (args: any[]) => any;
+      ok: Ok;
+      err: Err;
+      constructor(solc: string, f: (...args: any) => any, ok: Ok, err: Err) {
+        this.iface = new Interface([solc]);
+        this.frag = this.iface.fragments[0] as FunctionFragment;
+        this.f = f;
+        this.ok = ok;
+        this.err = err;
+      }
+    }
+
+    const unexpected = () => expect.fail("unexpected failure");
+    const inc0 = (x: number) => x + 1;
+
+    const inc = new Impl(
+      'function inc(uint256 x) external returns (uint256)',
+      ([x]) => [inc0(x.toNumber())],
+      ([x], res) => {
+        expect(res.length).to.equal(1);
+        expect(res[0].toNumber()).to.equal(inc0(x));
+      },
+      unexpected
+    );
+    const dup = new Impl(
+      'function dup(uint256 x) external returns (uint256, uint256)',
+      ([x]) => [x, x],
+      ([x], res) => {
+        expect(res.length).to.equal(2);
+        expect(res[0].toNumber()).to.equal(x);
+        expect(res[1].toNumber()).to.equal(x);
+      },
+      unexpected
+    );
+    const bad = new Impl(
+      'function bad() external returns (uint256)',
+      () => { throw new Error('failed'); },
+      unexpected,
+      (_, data) => console.log(data.slice(0, 10), defaultAbiCoder.decode(['string'], '0x' + data.slice(10)))
+    );
+
+    async function multicall(handlers: Impl[], calls: [Impl, any[]][]) {
+      const iface = new Interface([
+        'function multicall(bytes[] calldata data) external returns (bytes[] memory results)'
       ]);
+      const frag = iface.getFunction('multicall');
+      const server = new Server();
+      for (let impl of handlers) {
+        server.add(impl.iface, [{
+          type: impl.frag.format(),
+          func: (args) => impl.f(args as any[])
+        }]);
+      }
       const app = server.makeApp('/rpc/');
-      const calls = [
-        {
-          type: 'aaa',
-          args: [1],
-          check(v: ethers.utils.Result) {
-            expect(v.length).to.equal(1);
-            expect(v[0].toNumber()).to.equal(2);
-          }
-        },
-        {
-          type: 'bbb',
-          args: ['abc', 2],
-          check(v: ethers.utils.Result) {
-            expect(v.length).to.equal(2);
-            expect(v[0].toNumber()).to.equal(3);
-            expect(v[1]).to.equal("ABC");
-          }
-        }
-      ];
-      const calldata = multicall_iface.encodeFunctionData(multicall_frag, [calls.map(x => {
-        return test_iface.encodeFunctionData(x.type, x.args);
-      })]);
-      await supertest(app)
+      const res = await supertest(app)
         .post('/rpc/')
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
         .send({
           'sender': TEST_ADDRESS,
-          'data': calldata
+          'data': iface.encodeFunctionData(frag, [calls.map(([impl, args]) => impl.iface.encodeFunctionData(impl.frag, args))])
         })
         .expect(200)
-        .expect('Content-Type', /json/)
-        .then((response) => {
-          const calldata = multicall_iface.decodeFunctionResult(multicall_frag, response.body.data);
-          expect(calldata.length).to.equal(1);
-          expect(calldata[0].length).to.equal(calls.length);
-          calls.forEach((x, i) => x.check(test_iface.decodeFunctionResult(x.type, calldata[0][i])));
-        });
-    });
+        .expect('Content-Type', /json/);
+      const result = iface.decodeFunctionResult(frag, res.body.data);
+      expect(result.length).to.equal(1);
+      expect(result[0].length).to.equal(calls.length);
+      calls.forEach(([impl, args], i) => {
+        const data = result[0][i];
+        if ((data.length - 2) & 63) { // remove 0x, not 32-byte padded
+          impl.err(args, data);
+        } else {
+          impl.ok(args, impl.iface.decodeFunctionResult(impl.frag, data));
+        }
+      });
+    }
+
+    it('(0) calls: []',                                () => multicall([], []));
+    it('(2) calls: [inc(), dup()]',                    () => multicall([inc, dup], [[inc, [1]], [dup, [2]]]));
+    it('repeated calls: [inc(), inc(), inc()]',        () => multicall([inc],      [[inc, [1]], [inc, [2]], [inc, [3]]]));
+    it('missing impl: [inc(), bad()] => [OK, Error]',  () => multicall([inc],      [[inc, [1]], [bad, []]]));
+    it('throwing impl: [bad(), inc()] => [Error, OK]', () => multicall([inc, bad], [[bad, []],  [inc, [1]]]));
+
   });
 });

--- a/packages/server/tests/ccipRead.test.ts
+++ b/packages/server/tests/ccipRead.test.ts
@@ -165,4 +165,67 @@ describe('CCIP-Read', () => {
         });
     });
   });
+
+  describe('multicall tests', () => {
+    const multicall_iface = new ethers.utils.Interface([
+      'function multicall(bytes[] calldata data) external returns (bytes[] memory results)'
+    ]);
+    const multicall_frag = multicall_iface.getFunction('multicall');
+    const test_iface = new ethers.utils.Interface([
+      'function aaa(uint256 x) external returns (uint256)',
+      'function bbb(string y, uint256 z) external returns (uint256, string)',
+    ]);
+    it('answers multiple requests', async () => {
+      const server = new Server();
+      server.add(test_iface, [
+        {
+          type: 'aaa',
+          func([x]) { return [x.toNumber() + 1]; }
+        },
+        {
+          type: 'bbb',
+          func([y, z]) { return [z.toNumber() + 1, y.toUpperCase()]; }
+        },
+      ]);
+      const app = server.makeApp('/rpc/');
+      const calls = [
+        {
+          type: 'aaa',
+          args: [1],
+          check(v: ethers.utils.Result) {
+            expect(v.length).to.equal(1);
+            expect(v[0].toNumber()).to.equal(2);
+          }
+        },
+        {
+          type: 'bbb',
+          args: ['abc', 2],
+          check(v: ethers.utils.Result) {
+            expect(v.length).to.equal(2);
+            expect(v[0].toNumber()).to.equal(3);
+            expect(v[1]).to.equal("ABC");
+          }
+        }
+      ];
+      const calldata = multicall_iface.encodeFunctionData(multicall_frag, [calls.map(x => {
+        return test_iface.encodeFunctionData(x.type, x.args);
+      })]);
+      await supertest(app)
+        .post('/rpc/')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({
+          'sender': TEST_ADDRESS,
+          'data': calldata
+        })
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .then((response) => {
+          const calldata = multicall_iface.decodeFunctionResult(multicall_frag, response.body.data);
+          expect(calldata.length).to.equal(1);
+          expect(calldata[0].length).to.equal(calls.length);
+          calls.forEach((x, i) => x.check(test_iface.decodeFunctionResult(x.type, calldata[0][i])));
+        });
+    });
+  });
 });


### PR DESCRIPTION
Added built-in `multicall()` support and test.

Nested multicall (`multicall(multicall(...))`) is allowed.