### PR TITLE
Handle REDACTED sender address

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -148,6 +148,10 @@ export class Server {
       callData = req.body.data;
     }
 
+    if (sender == 'REDACTED') {
+      sender = '0x0000000000000000000000000000000000000000';
+    }
+
     if (!isAddress(sender) || !isBytesLike(callData)) {
       res.status(400).json({
         message: 'Invalid request format',

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -76,22 +76,29 @@ export class Server {
    */
   addMulticallSupport() {
     const selector = ethers.utils.id('Error(string)').slice(0, 10);
-    this.add(['function multicall(bytes[] calldata data) external returns (bytes[] memory results)'], [{
-      type: 'multicall',
-      func: async(args: ethers.utils.Result, {to}: RPCCall) => [
-        await Promise.all(args[0].map(async (data: any) => {
-          let error;
-          try {
-            let {status, body} = await this.call({to, data});
-            if (status === 200) return body.data; // Q: should this be 2XX?
-            error = body.message || 'unknown error';
-          } catch (err) {
-            error = String(err); // Q: should this include status?
-          }
-          return ethers.utils.hexConcat([selector, ethers.utils.defaultAbiCoder.encode(['string'], [error])]);
-        }))
+    this.add(
+      ['function multicall(bytes[] calldata data) external returns (bytes[] memory results)'],
+      [
+        {
+          type: 'multicall',
+          func: async (args: ethers.utils.Result, { to }: RPCCall) => [
+            await Promise.all(
+              args[0].map(async (data: any) => {
+                let error;
+                try {
+                  let { status, body } = await this.call({ to, data });
+                  if (status === 200) return body.data; // Q: should this be 2XX?
+                  error = body.message || 'unknown error';
+                } catch (err) {
+                  error = String(err); // Q: should this include status?
+                }
+                return ethers.utils.hexConcat([selector, ethers.utils.defaultAbiCoder.encode(['string'], [error])]);
+              })
+            ),
+          ],
+        },
       ]
-    }]);
+    );
   }
 
   /**


### PR DESCRIPTION
ENS Official CCIP Gateway Proxy (https://ccip-v2.ens.xyz) redact sender address with `REDACTED`. However, ccip-read-server implementation doesn't support `REDACTED` and response with "Invalid request format". Causing resolving process to fail.

**For example:** https://op-gateway-worker.optidomains.workers.dev/REDACTED/0xea9cd3bf000000000000000000000000f079f2a30f3c797f8e6920ad783b74846a9acbf4000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000002000001ff000000000000000000000000000000000000000000000000000000000102200304ff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020438bfe3fc990665148f8ac1638323ab84054a5c22a1ab61fe63cebc3040129cb0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000020438bfe3fc990665148f8ac1638323ab84054a5c22a1ab61fe63cebc3040129cb000000000000000000000000000000000000000000000000000000000000000b6465736372697074696f6e000000000000000000000000000000000000000000.json

**Response:** Invalid request format

We fix this by checking if sender is `REDACTED` then set it to `address(0)`